### PR TITLE
Added icon_link_to helper method

### DIFF
--- a/app/helpers/rawnet_admin/resource_helper.rb
+++ b/app/helpers/rawnet_admin/resource_helper.rb
@@ -1,26 +1,24 @@
 module RawnetAdmin
   module ResourceHelper
     def show_link_to(route, text='Show')
-      link_to route do
-        "<i class='glyphicon glyphicon-search'></i> #{text}".html_safe
-      end
+      icon_link_to text, route, 'search'
     end
 
     def edit_link_to(route, text='Edit')
-      link_to route do
-        "<i class='glyphicon glyphicon-pencil'></i> #{text}".html_safe
-      end
+      icon_link_to text, route, 'pencil'
     end
 
     def delete_link_to(route, confirm="Are you sure?")
-      link_to route, :method => :delete, data: {:confirm => confirm} do
-        "<i class='glyphicon glyphicon-trash'></i> Delete".html_safe
-      end
+      icon_link_to 'Delete', route, 'trash', :method => :delete, data: {:confirm => confirm}
     end
 
     def view_link_to(route, text="View")
-      link_to route, :target => "_blank" do
-        "<i class='glyphicon glyphicon-new-window'></i> #{text}".html_safe
+      icon_link_to text, route, 'new-window', {:target => "_blank" }
+    end
+
+    def icon_link_to(text, route, icon, opts={})
+      link_to route, opts do
+        "<i class='glyphicon glyphicon-#{icon}'></i> #{text}".html_safe
       end
     end
 

--- a/app/helpers/rawnet_admin/resource_helper.rb
+++ b/app/helpers/rawnet_admin/resource_helper.rb
@@ -1,19 +1,25 @@
 module RawnetAdmin
   module ResourceHelper
-    def show_link_to(route, text='Show')
-      icon_link_to text, route, 'search'
+    def show_link_to(route, text='Show', options={})
+      icon_link_to text, route, 'search', options
     end
 
-    def edit_link_to(route, text='Edit')
-      icon_link_to text, route, 'pencil'
+    def edit_link_to(route, text='Edit', options={})
+      icon_link_to text, route, 'pencil', options
     end
 
-    def delete_link_to(route, confirm="Are you sure?")
-      icon_link_to 'Delete', route, 'trash', :method => :delete, data: {:confirm => confirm}
+    def delete_link_to(route, text='Delete', options={})
+      options = {
+          method: :delete,
+          data: {
+              confirm: "Are you sure?"
+          }
+      }.merge(options)
+      icon_link_to 'Delete', route, 'trash', options
     end
 
-    def view_link_to(route, text="View")
-      icon_link_to text, route, 'new-window', {:target => "_blank" }
+    def view_link_to(route, text="View", options={})
+      icon_link_to text, route, 'new-window', {:target => "_blank" }.merge(options)
     end
 
     def icon_link_to(text, route, icon, opts={})


### PR DESCRIPTION
Added an extra utility method and refactored the existing link_to helpers. 

```
icon_link_to 'Duplicate', [:duplicate, resource], 'duplicate'
```

I decided to match the ActiveSupport link_to parameters (specifically text first, link second), since it's what we expect. Unfortunately the other helpers use the reverse (link, text), and I don't want to switch it around and break other sites. Unless we think it's worth doing it now before too many sites are using RA? 
