### PR TITLE
Allow non-anchor links to click through normally

### DIFF
--- a/app/assets/javascripts/rawnet_admin/modules/menu.js
+++ b/app/assets/javascripts/rawnet_admin/modules/menu.js
@@ -36,7 +36,7 @@ RawnetAdmin.menu = function(){
     activeMenu.addClass('active');
     activeSelector.addClass('active');
 
-    $(document).on('click', '#mainNav a, #dashboardNav a', function(e) {
+    $(document).on('click', '#mainNav a[href^="#"], #dashboardNav a[href^="#"]', function(e) {
       e.preventDefault();
       toggleNav($(this));
     });


### PR DESCRIPTION
Sometimes main nav links need to be clickable, instead of opening the subnav
